### PR TITLE
auto bump and bug fix for xs/enertgy mix up

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,7 @@ jobs:
         VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
         PLACEHOLDER='__version__ = "develop"'
         VERSION_FILE='openmc_data_to_json/__init__.py'
+
         # ensure the placeholder is there. If grep doesn't find the placeholder
         # it exits with exit code 1 and github actions aborts the build. 
         grep "$PLACEHOLDER" "$VERSION_FILE"

--- a/openmc_data_to_json/__init__.py
+++ b/openmc_data_to_json/__init__.py
@@ -1,4 +1,3 @@
-__version__ = "develop"
 
 from .core import (
     open_h5,
@@ -10,3 +9,5 @@ from .core import (
     reactions_in_h5,
     trim_zeros_from_front_and_back_of_list,
 )
+
+__version__ = "develop"

--- a/openmc_data_to_json/core.py
+++ b/openmc_data_to_json/core.py
@@ -452,10 +452,7 @@ def cross_section_h5_to_json(
             energy = isotope_object.energy[temperature]
             cross_section = isotope_object[reaction].xs[temperature](energy)
 
-            (
-                shorter_energy,
-                shorter_cross_section,
-            ) = trim_zeros_from_front_and_back_of_list(cross_section, energy)
+            shorter_cross_section, shorter_energy = trim_zeros_from_front_and_back_of_list(cross_section, energy)
 
             if (
                 int(isotope_object._mass_number) != 0

--- a/setup.py
+++ b/setup.py
@@ -34,3 +34,6 @@ def main():
         ],
         tests_require=["pytest-cov"],
     )
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="openmc_data_to_json",
-    version="0.0.15",
+    version="0.0.16",
     author="Jonathan Shimwell",
     description="A tool for selectively extracting cross sections from OpenMC h5 files.",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,36 @@
-import setuptools
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(
-    name="openmc_data_to_json",
-    version="0.0.16",
-    author="Jonathan Shimwell",
-    description="A tool for selectively extracting cross sections from OpenMC h5 files.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/openmc_data_storage/openmc_data_to_json",
-    packages=setuptools.find_packages(),
-    zip_safe=True,
-    package_dir={"openmc_data_to_json": "openmc_data_to_json"},
-    scripts=['openmc_data_to_json/openmc-data-to-json'],
-    package_data={
-        "openmc_data_to_json": [
-            "requirements.txt",
-            "README.md",
-            "LICENSE",
+def main():
+    "Executes setup when this script is the top-level"
+    import openmc_data_to_json as app
+
+    setup(
+        name="openmc_data_to_json",
+        version=app.__version__,,
+        author="Jonathan Shimwell",
+        description="A tool for selectively extracting cross sections from OpenMC h5 files.",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/openmc_data_storage/openmc_data_to_json",
+        packages=find_packages(),
+        zip_safe=True,
+        package_dir=find_packages(),
+        scripts=['openmc_data_to_json/openmc-data-to-json'],
+        package_data={
+            "openmc_data_to_json": [
+                "requirements.txt",
+                "README.md",
+                "LICENSE",
+            ],
+            # "tests": [
+            #     "Li.h5"
+            # ]
+        },
+        install_requires=[
+            "h5py"
         ],
-        # "tests": [
-        #     "Li.h5"
-        # ]
-    },
-    install_requires=[
-        "h5py"
-    ],
-    tests_require=["pytest-cov"],
-)
+        tests_require=["pytest-cov"],
+    )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="openmc_data_to_json",
-    version="0.0.14",
+    version="0.0.15",
     author="Jonathan Shimwell",
     description="A tool for selectively extracting cross sections from OpenMC h5 files.",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def main():
         url="https://github.com/openmc_data_storage/openmc_data_to_json",
         packages=find_packages(),
         zip_safe=True,
-        package_dir=find_packages(),
+        package_dir={"openmc_data_to_json": "openmc_data_to_json"},
         scripts=['openmc_data_to_json/openmc-data-to-json'],
         package_data={
             "openmc_data_to_json": [


### PR DESCRIPTION
Trying to implement the automatic version naming with each GitHub Action as demonstrated https://github.com/grst/python-ci-versioneer

The python package should get the version number from the github release tag and upload to pypi with that version 