### PR TITLE
no longer importing to get __version__

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,7 @@ jobs:
         # from refs/tags/v1.2.3 get 1.2.3
         VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
         PLACEHOLDER='__version__ = "develop"'
-        VERSION_FILE='openmc_data_to_json/__init__.py'
+        VERSION_FILE='setup.py'
 
         # ensure the placeholder is there. If grep doesn't find the placeholder
         # it exits with exit code 1 and github actions aborts the build. 

--- a/openmc_data_to_json/__init__.py
+++ b/openmc_data_to_json/__init__.py
@@ -9,5 +9,3 @@ from .core import (
     reactions_in_h5,
     trim_zeros_from_front_and_back_of_list,
 )
-
-__version__ = "develop"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,10 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 def main():
-    "Executes setup when this script is the top-level"
-    import openmc_data_to_json as app
 
     setup(
         name="openmc_data_to_json",
-        version=app.__version__,
+        version="develop",
         author="Jonathan Shimwell",
         description="A tool for selectively extracting cross sections from OpenMC h5 files.",
         long_description=long_description,
@@ -34,6 +32,7 @@ def main():
         ],
         tests_require=["pytest-cov"],
     )
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This removes the need to import the package in the setup to obtain app.__version__.

Now the version is "develop" and the github actions script shangs the setup.py file directly